### PR TITLE
Always use the correct dtype and test with float64

### DIFF
--- a/pykit/tests/test_theanolike.py
+++ b/pykit/tests/test_theanolike.py
@@ -28,6 +28,7 @@ class Variable(object):
     def __mul__(self, other):
         assert self.type.dtype == other.type.dtype, "TODO dtype upcast"
 
+        # Compute the output broadcast flag.
         if len(other.type.broadcastable) > len(self.type.broadcastable):
             n = len(other.type.broadcastable) - len(self.type.broadcastable)
             self_br = [True] * n + self.type.broadcastable

--- a/pykit/tests/test_theanolike.py
+++ b/pykit/tests/test_theanolike.py
@@ -140,12 +140,8 @@ def map_type(type):
         # array of any order
         dtype = map_type(type.dtype)
         return types.Array(dtype, len(type.broadcastable), 'A')
-
-    # do something actual here
-    elif type == 'float32':
-        return types.Float32
     else:
-        return types.Float64
+        return getattr(types, type.capitalize())
 
 def type_from_outputs(outputs):
     """
@@ -268,7 +264,7 @@ entry:
 
 class TestPykitMapping(unittest.TestCase):
     def test_pykit_mapping(self):
-        fvector = TensorType('int', [False])
+        fvector = TensorType('float64', [False])
 
         x = Variable(fvector)
         y = Variable(fvector)


### PR DESCRIPTION
The int dtype writting is uglier: 
Array(base=Typedef(name='Int', type=Int(bits=32, signed=False))

compared to for float32:

Array(base=Real(bits=32), ndim=1, order='A')

we don't need to make it harder to understand the example :)
